### PR TITLE
Add Apache-2.0 approval to Dependency review

### DIFF
--- a/.github/dependency-review-config
+++ b/.github/dependency-review-config
@@ -1,0 +1,11 @@
+# Note: For external configuration files, the option names use underscores instead of dashes. Example: fail_on_severity
+fail_on_severity: high
+# Possible values: Any SPDX-compliant license identifiers or expressions from https://spdx.org/licenses/
+allow_licenses:
+  - 'GPL-3.0'
+  - 'BSD-3-Clause'
+  - 'MIT'
+  - 'Apache-2.0'
+# workaround for events other than PR
+base_ref: ${{ github.event.pull_request.base.sha || 'main' }}
+head_ref: ${{ github.event.pull_request.head.sha || github.ref }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,9 +22,4 @@ jobs:
     - name: Dependency Review
       uses: actions/dependency-review-action@v4
       with:
-        fail-on-severity: high
-        # Possible values: Any SPDX-compliant license identifiers or expressions from https://spdx.org/licenses/
-        allow-licenses: GPL-3.0, BSD-3-Clause, MIT
-        # workaround for events other than PR
-        base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
-        head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
+        config-file: './.github/dependency-review-config.yml'


### PR DESCRIPTION
<!--- You're awesome! Make a PR title as awesome as you for awesome release notes.-->

## Description
<!--- Please use GitHub Copilot to generate description. -->
This pull request focuses on configuring the dependency review process by moving configuration options to an external file and updating the workflow to use this new configuration file. The main changes include the creation of a new configuration file and the modification of the workflow file to reference this new configuration.

Configuration changes:

* [`.github/dependency-review-config.yml`](diffhunk://#diff-f446133098c5f76d58f30b552794e49e77f5f2291af92c4f917e1ee60109bc27R1-R11): Added a new configuration file to specify dependency review options, including `fail_on_severity`, `allow_licenses`, `base_ref`, and `head_ref`.

Workflow updates:

* [`.github/workflows/dependency-review.yml`](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18L25-R25): Updated the dependency review action to use the new external configuration file instead of inline options.

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Screenshots (if appropriate):

## Types of changes
- [ ] We use labels --->

## Checklist:
- [ ] Works on my PC!
