### PR TITLE
Change from allow-licenes to deny-licenses and add denied licenses

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -27,35 +27,7 @@ jobs:
         fail-on-severity: high
         # Possible values: Any SPDX-compliant license identifiers or expressions from https://spdx.org/licenses/
         # Licenses considered problematic for most projects
-        deny-licenses:
-          - GPL-*
-          - LGPL-*
-          - AGPL-*
-          - SSPL-1.0
-          - CC-*
-          - Anti-996
-          - BUSL-1.1
-          - Commons-Clause
-          - Confluent-Community
-          - Elastic-2.0
-          - Fair-Source
-          - Hippocratic-2.1
-          - Prosperity
-          - RSAL-1.0
-          - AFL-3.0
-          - Artistic-1.0
-          - BSD-4-Clause
-          - CPAL-1.0
-          - CPOL
-          - EUPL-1.2
-          - JSON
-          - MS-RL
-          - NPL-1.0
-          - OSL-3.0
-          - QPL-1.0
-          - RPL-1.5
-          - Sleepycat
-          - WTFPL
+        deny-licenses: GPL-*, LGPL-*, AGPL-*, SSPL-1.0, CC-*
         # workaround for events other than PR
         base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
         head-ref: ${{ github.event.pull_request.head.sha || github.ref }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -56,7 +56,6 @@ jobs:
           - RPL-1.5
           - Sleepycat
           - WTFPL
-
         # workaround for events other than PR
         base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
         head-ref: ${{ github.event.pull_request.head.sha || github.ref }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,8 +26,7 @@ jobs:
       with:
         fail-on-severity: high
         # Possible values: Any SPDX-compliant license identifiers or expressions from https://spdx.org/licenses/
-        # Licenses considered problematic for most projects
-        deny-licenses: GPL-*, LGPL-*, AGPL-*, SSPL-1.0, CC-*
+        deny-licenses: GPL-*, LGPL-*, AGPL-*, SSPL-1.0, CC-*, Anti-996, BUSL-1.1, Commons-Clause, Confluent-Community, Elastic-2.0, Fair-Source, Hippocratic-2.1, Prosperity, RSAL-1.0, AFL-3.0, Artistic-1.0, BSD-4-Clause, CPAL-1.0, CPOL, EUPL-1.2, JSON, MS-RL, NPL-1.0, OSL-3.0, QPL-1.0, RPL-1.5, Sleepycat, WTFPL
         # workaround for events other than PR
         base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
         head-ref: ${{ github.event.pull_request.head.sha || github.ref }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,18 +28,11 @@ jobs:
         # Possible values: Any SPDX-compliant license identifiers or expressions from https://spdx.org/licenses/
         # Licenses considered problematic for most projects
         deny-licenses:
-          # Strong Copyleft Licenses
           - GPL-*
           - LGPL-*
-          
-          # Network/Server Copyleft
           - AGPL-*
           - SSPL-1.0
-
-          # Creative Commons Non-Commercial (NC)
           - CC-*
-          
-          # Source-Available & Ethical Licenses
           - Anti-996
           - BUSL-1.1
           - Commons-Clause
@@ -49,8 +42,6 @@ jobs:
           - Hippocratic-2.1
           - Prosperity
           - RSAL-1.0
-          
-          # Other Restrictive Licenses
           - AFL-3.0
           - Artistic-1.0
           - BSD-4-Clause

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,7 +26,35 @@ jobs:
       with:
         fail-on-severity: high
         # Possible values: Any SPDX-compliant license identifiers or expressions from https://spdx.org/licenses/
-        allow-licenses: GPL-3.0, BSD-3-Clause, MIT, Apache-2.0
+        # Licenses considered problematic for most projects
+        deny-licenses:
+          - AGPL-1.0
+          - AGPL-3.0
+          - SSPL-1.0
+          - Commons-Clause
+          - CPAL-1.0
+          - OSL-3.0
+          - EUPL-1.2
+          - NPL-1.0
+          - RPL-1.5
+          - MS-RL
+          - CC-BY-NC-4.0
+          - CC-BY-NC-SA-4.0
+          - GPL-2.0
+          - GPL-3.0
+          - LGPL-2.0
+          - LGPL-2.1
+          - LGPL-3.0
+          - AGPL-1.0-only
+          - AGPL-3.0-only
+          - AGPL-3.0-or-later
+          - CC-BY-ND-4.0
+          - Sleepycat
+          - JSON
+          - WTFPL
+          - Artistic-1.0
+          - CPOL
+          - Prosperity
         # workaround for events other than PR
         base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
         head-ref: ${{ github.event.pull_request.head.sha || github.ref }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,33 +28,44 @@ jobs:
         # Possible values: Any SPDX-compliant license identifiers or expressions from https://spdx.org/licenses/
         # Licenses considered problematic for most projects
         deny-licenses:
-          - AGPL-1.0
-          - AGPL-3.0
+          # Strong Copyleft Licenses
+          - GPL-*
+          - LGPL-*
+          
+          # Network/Server Copyleft
+          - AGPL-*
           - SSPL-1.0
+
+          # Creative Commons Non-Commercial (NC)
+          - CC-*
+          
+          # Source-Available & Ethical Licenses
+          - Anti-996
+          - BUSL-1.1
           - Commons-Clause
-          - CPAL-1.0
-          - OSL-3.0
-          - EUPL-1.2
-          - NPL-1.0
-          - RPL-1.5
-          - MS-RL
-          - CC-BY-NC-4.0
-          - CC-BY-NC-SA-4.0
-          - GPL-2.0
-          - GPL-3.0
-          - LGPL-2.0
-          - LGPL-2.1
-          - LGPL-3.0
-          - AGPL-1.0-only
-          - AGPL-3.0-only
-          - AGPL-3.0-or-later
-          - CC-BY-ND-4.0
-          - Sleepycat
-          - JSON
-          - WTFPL
-          - Artistic-1.0
-          - CPOL
+          - Confluent-Community
+          - Elastic-2.0
+          - Fair-Source
+          - Hippocratic-2.1
           - Prosperity
+          - RSAL-1.0
+          
+          # Other Restrictive Licenses
+          - AFL-3.0
+          - Artistic-1.0
+          - BSD-4-Clause
+          - CPAL-1.0
+          - CPOL
+          - EUPL-1.2
+          - JSON
+          - MS-RL
+          - NPL-1.0
+          - OSL-3.0
+          - QPL-1.0
+          - RPL-1.5
+          - Sleepycat
+          - WTFPL
+
         # workaround for events other than PR
         base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
         head-ref: ${{ github.event.pull_request.head.sha || github.ref }}


### PR DESCRIPTION
<!--- You're awesome! Make a PR title as awesome as you for awesome release notes.-->

## Description
<!--- Please use GitHub Copilot to generate description. -->
This pull request includes an update to the `.github/workflows/dependency-review.yml` file to enhance the dependency review process by specifying a list of problematic licenses to deny.

Changes to dependency review workflow:

* [`.github/workflows/dependency-review.yml`](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18L29-R68): Replaced `allow-licenses` with `deny-licenses` to list licenses that are considered problematic for most projects, including strong copyleft licenses, network/server copyleft licenses, Creative Commons Non-Commercial licenses, source-available & ethical licenses, and other restrictive licenses.
## Additional information
- [ ] Issues this PR closes are linked under development --->
- This PR is related to issue: 

## Screenshots (if appropriate):

## Types of changes
- [ ] We use labels --->

## Checklist:
- [ ] Works on my PC!
