### PR TITLE
Pin uv with sha in zizmor workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 #v5
 
       - name: Run zizmor 🌈
         run: uvx zizmor --format sarif . > results.sarif 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
 
       - name: Run zizmor 🌈
         run: uvx zizmor --format sarif . > results.sarif 


### PR DESCRIPTION
<!--- You're awesome! Make a PR title as awesome as you for awesome release notes.-->

## Description
<!--- Please use GitHub Copilot to generate description. -->
This pull request updates the GitHub Actions workflow configuration to use a specific commit hash for the `astral-sh/setup-uv` action instead of a version tag.

Workflow configuration update:

* [`.github/workflows/zizmor.yml`](diffhunk://#diff-8e6408444d2bf2bed6f02c5dc62a7f1f6ab7337eae098d332986e6a81411aeb7L26-R26): Changed the `uses` field for the `astral-sh/setup-uv` action to reference a specific commit hash (`d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86`) instead of the `v5` tag. This ensures a more deterministic and secure build process.
## Additional information
- [ ] Issues this PR closes are linked under development --->
- This PR is related to issue: 

## Screenshots (if appropriate):

## Types of changes
- [x] We use labels --->

## Checklist:
- [ ] Works on my PC!
