### PR TITLE
Zizmor only if there are workflows or actions

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -11,36 +11,77 @@ on:
 jobs:
   zizmor:
     name: zizmor latest via PyPI
+
     runs-on: ubuntu-latest
+
     permissions:
       security-events: write
       contents: read # only needed for private repos
       actions: read # only needed for private repos
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
 
+      - name: Detect workflows or actions
+        id: detect_targets
+        run: |
+          set -euo pipefail
+
+          has_workflows=false
+          if [ -d ".github/workflows" ] && find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) -print -quit | grep -q .; then
+            has_workflows=true
+          fi
+
+          has_actions=false
+          if find . \
+            -path './.git' -prune -o \
+            -type f \( -name 'action.yml' -o -name 'action.yaml' -o -name 'action.json' \) \
+            -print -quit | grep -q .; then
+            has_actions=true
+          fi
+
+          if [ "$has_workflows" = true ] || [ "$has_actions" = true ]; then
+            echo "has_targets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_targets=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No workflows or actions found; skipping zizmor scan." >&2
+          fi
+
+          echo "has_workflows=$has_workflows" >> "$GITHUB_OUTPUT"
+          echo "has_actions=$has_actions" >> "$GITHUB_OUTPUT"
+
+          echo "Workflows detected: $has_workflows"
+          echo "Actions detected: $has_actions"
+
       - name: Install the latest version of uv
+        if: steps.detect_targets.outputs.has_targets == 'true'
         uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6
 
       - name: Run zizmor 🌈
         id: run_zizmor
+        if: steps.detect_targets.outputs.has_targets == 'true'
         run: |
+          set -o pipefail
+
+          rm -f results.sarif zizmor.log
+
           if uvx zizmor --format sarif . > results.sarif 2>zizmor.log; then
-            echo "has_results=true" >> $GITHUB_OUTPUT
+            echo "has_results=true" >> "$GITHUB_OUTPUT"
           else
-            status=$? # exit status of the previous command
+            status=$?
             echo "zizmor stderr output:" >&2
             cat zizmor.log >&2
             if grep -qi "no inputs collected" zizmor.log; then
               echo "No workflows or actions detected; treating as success." >&2
-              echo "has_results=false" >> $GITHUB_OUTPUT
+              echo "has_results=false" >> "$GITHUB_OUTPUT"
             else
               exit "$status"
             fi
           fi
+
           rm -f zizmor.log
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,11 +26,27 @@ jobs:
         uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6
 
       - name: Run zizmor 🌈
-        run: uvx zizmor --format sarif . > results.sarif 
+        id: run_zizmor
+        run: |
+          if uvx zizmor --format sarif . > results.sarif 2>zizmor.log; then
+            echo "has_results=true" >> $GITHUB_OUTPUT
+          else
+            status=$? # exit status of the previous command
+            echo "zizmor stderr output:" >&2
+            cat zizmor.log >&2
+            if grep -qi "no inputs collected" zizmor.log; then
+              echo "No workflows or actions detected; treating as success." >&2
+              echo "has_results=false" >> $GITHUB_OUTPUT
+            else
+              exit "$status"
+            fi
+          fi
+          rm -f zizmor.log
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
 
       - name: Upload SARIF file
+        if: steps.run_zizmor.outputs.has_results == 'true'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
<!--- You're awesome! Make a PR title as awesome as you for awesome release notes.-->

## Description
<!--- Please use GitHub Copilot to generate description. -->
This pull request enhances the `zizmor.yml` GitHub Actions workflow to make the Zizmor scan more efficient and robust. The workflow now checks if there are any workflows or actions present before running the scan, and it gracefully handles cases where there are no inputs to scan, avoiding unnecessary failures.

Key improvements to the workflow:

**Workflow Target Detection:**
* Added a step (`detect_targets`) to detect if any workflow (`.yml`/`.yaml` in `.github/workflows`) or action (`action.yml`/`action.yaml`/`action.json`) files are present before proceeding with the Zizmor scan. This prevents running the scan when there are no relevant files.

**Conditional Execution:**
* Modified the install and scan steps to run only if relevant workflows or actions are detected, using outputs from the detection step.

**Robust Error Handling:**
* Improved the Zizmor scan step to handle cases where no inputs are collected by parsing the log output, treating this as a successful (but empty) scan rather than a failure.

**SARIF Upload Optimization:**
* The SARIF upload step now runs only if the Zizmor scan produced results, preventing attempts to upload empty or missing reports.

## Additional information
- [ ] Issues this PR closes are linked under development --->
- This PR is related to issue: 

## Screenshots (if appropriate):

## Types of changes
- [ ] We use labels --->

## Checklist:
- [ ] Works on my PC!
