### PR TITLE
DR workflow, use ubuntu-slim and timeout 5min

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,8 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
     steps:
 
     - name: Checkout Repository


### PR DESCRIPTION
<!--- You're awesome! Make a PR title as awesome as you for awesome release notes.-->

## Description
<!--- Please use GitHub Copilot to generate description. -->
This pull request makes a minor update to the `dependency-review.yml` GitHub Actions workflow, specifying a more lightweight runner and setting a timeout for the job.

* Changed the workflow runner from `ubuntu-latest` to `ubuntu-slim` and set a job timeout of 5 minutes to improve efficiency and prevent long-running jobs.

## Additional information
- [ ] Issues this PR closes are linked under development --->
- This PR is related to issue: 

## Screenshots (if appropriate):

## Types of changes
- [x] We use labels --->

## Checklist:
- [ ] Works on my PC!
